### PR TITLE
examples(onnx, quant):add examples

### DIFF
--- a/examples/export_onnx/export_to_onnx.py
+++ b/examples/export_onnx/export_to_onnx.py
@@ -1,0 +1,505 @@
+"""Структура эксперимента:
+1. Частичное обучение FP32-модели.
+2. Перевод модели в режим model.eval().
+3. Экспорт через torch.onnx.export → файл .onnx.
+4. Проверка структуры через onnx.checker.
+5. Запуск через FedCore ONNXInferenceModel (обёртка FedCoreOnnxRunner).
+6. Сравнение ответов PyTorch и ONNX.
+
+Частичное обучение означает: выполняется несколько эпох на уменьшенной
+выборке, чтобы получить осмысленный FP32-baseline для экспорта и сравнения.
+Этого достаточно для демонстрации переноса модели в ONNX; полный цикл
+обучения здесь не требуется, потому что цель примера — корректный экспорт
+и совпадение ответов, а не максимальная accuracy.
+
+Используемые элементы FedCore:
+* CLF_MODELS — реестр архитектур; отсюда берётся ResNet18;
+* ONNXInferenceModel — загрузка .onnx и инференс через ONNX Runtime.
+FedCore.export() не используется: метод сейчас пустой (pass).
+
+Классы примера:
+* ResNet18ExperimentModel — создание и частичное обучение FP32 ResNet18;
+* OnnxExporter — torch.onnx.export + onnx.checker;
+* FedCoreOnnxRunner — обёртка над ONNXInferenceModel с нормализацией выхода;
+* MetricEvaluator — accuracy / размер / latency для PyTorch и ONNX;
+* Infographic — PNG: accuracy, размер, latency.
+
+Вывод в консоль:
+Данные
+Исходная FP32-модель
+Экспорт в ONNX
+FedCore-инференс и сравнение
+CSV + инфографика
+
+Проводимые сравнения:
+* accuracy PyTorch и ONNX на одном test-наборе;
+* размер .pt / .onnx;
+* latency batch=1;
+* max |PyTorch − ONNX| на одном batch;
+* проверка onnx.checker;
+* forward с batch=1 и batch=4 (dynamic axes).
+
+Критерий успешного завершения:
+checker без ошибок, формы совпадают, расхождение малое (порядка 1e-4…1e-5),
+CSV и PNG созданы.
+
+Запуск::
+
+    cd examples/export_onnx
+    python export_to_onnx.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import random
+import statistics
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, Subset
+from torchvision import datasets, transforms
+
+from fedcore.inference.onnx import ONNXInferenceModel
+from fedcore.models.backbone.convolutional.resnet import CLF_MODELS
+
+try:
+    import onnx
+except ImportError as error:
+    raise SystemExit(
+        "Нужен пакет onnx для onnx.checker. Установка: pip install onnx"
+    ) from error
+
+
+@dataclass
+class Config:
+    """Параметры воспроизводимого эксперимента экспорта в ONNX."""
+
+    seed: int = 42
+    epochs: int = 1
+    train_samples: int = 2_000
+    test_samples: int = 500
+    batch_size: int = 64
+    opset_version: int = 17
+    output_dir: Path = REPO_ROOT / "results" / "export_onnx"
+    data_dir: Path = REPO_ROOT / "datasets"
+
+
+@dataclass
+class Metrics:
+    """Метрики одной версии модели для CSV и инфографики."""
+
+    model: str
+    accuracy: float
+    size_mib: float
+    latency_ms: float
+
+
+class Cifar10Data:
+    """Загрузка CIFAR-10 и подготовка train/test DataLoader.
+
+    CIFAR-10 содержит 60 000 цветных изображений 32×32 десяти классов.
+    Подмножества используются для ускорения демонстрационного прогона на CPU.
+    """
+
+    def __init__(self, config: Config):
+        transform = transforms.Compose(
+            [
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    (0.4914, 0.4822, 0.4465),
+                    (0.2470, 0.2435, 0.2616),
+                ),
+            ]
+        )
+        train = datasets.CIFAR10(
+            config.data_dir, train=True, download=True, transform=transform
+        )
+        test = datasets.CIFAR10(
+            config.data_dir, train=False, download=True, transform=transform
+        )
+        generator = torch.Generator().manual_seed(config.seed)
+        train_ids = torch.randperm(len(train), generator=generator)
+        test_ids = torch.randperm(len(test), generator=generator)
+
+        self.train = DataLoader(
+            Subset(train, train_ids[: config.train_samples]),
+            batch_size=config.batch_size,
+            shuffle=True,
+            num_workers=0,
+            generator=generator,
+        )
+        self.test = DataLoader(
+            Subset(test, test_ids[: config.test_samples]),
+            batch_size=config.batch_size,
+            shuffle=False,
+            num_workers=0,
+        )
+
+
+class ResNet18ExperimentModel:
+    """Создание и частичное обучение исходной ResNet18 из реестра FedCore.
+
+    ``CLF_MODELS`` — реестр поддерживаемых архитектур FedCore.
+    Из него берётся torchvision ResNet18; входной stem адаптируется под
+    CIFAR-10 (изображения 32×32 вместо ImageNet 224×224).
+    """
+
+    @staticmethod
+    def create() -> nn.Module:
+        """Создание ResNet18 из FedCore с входом под 32×32."""
+
+        model = CLF_MODELS["ResNet18"](weights=None, num_classes=10)
+        model.conv1 = nn.Conv2d(3, 64, 3, stride=1, padding=1, bias=False)
+        model.maxpool = nn.Identity()
+        return model.cpu()
+
+    @staticmethod
+    def train(model: nn.Module, loader: DataLoader, epochs: int) -> None:
+        """Частичный FP32-цикл: forward → loss → backward → optimizer.
+
+        Цикл частичный намеренно: цель примера — экспорт и совпадение ответов
+        PyTorch/ONNX, а не достижение максимальной accuracy на CIFAR-10.
+        """
+
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+        loss_function = nn.CrossEntropyLoss()
+        for epoch in range(epochs):
+            model.train()
+            loss_sum, correct, total = 0.0, 0, 0
+            for images, labels in loader:
+                optimizer.zero_grad()
+                logits = model(images)
+                loss = loss_function(logits, labels)
+                loss.backward()
+                optimizer.step()
+                loss_sum += loss.item() * len(labels)
+                correct += (logits.argmax(1) == labels).sum().item()
+                total += len(labels)
+            print(
+                f"Epoch {epoch + 1}/{epochs}: "
+                f"loss={loss_sum / total:.4f}, accuracy={correct / total:.2%}"
+            )
+        model.eval()
+
+
+class OnnxExporter:
+    """Экспорт PyTorch-модели в ONNX и проверка структуры файла.
+
+    Экспорт выполняется через ``torch.onnx.export``: API ``FedCore.export()``
+    сейчас пустой (``pass``), поэтому используется прямой экспорт. Имя входа
+    обязательно ``input`` — так жёстко ожидает ``ONNXInferenceModel`` FedCore.
+    """
+
+    @staticmethod
+    def export(
+        model: nn.Module, example_input: torch.Tensor, path: Path, opset: int
+    ) -> Path:
+        """Сохранение .onnx с динамическим размером batch."""
+
+        model.eval()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # dynamo=False нужен в новых PyTorch; в 2.3.1 такого аргумента ещё нет.
+        export_kwargs = dict(
+            export_params=True,
+            opset_version=opset,
+            do_constant_folding=True,
+            input_names=["input"],
+            output_names=["logits"],
+            dynamic_axes={
+                "input": {0: "batch_size"},
+                "logits": {0: "batch_size"},
+            },
+        )
+        try:
+            torch.onnx.export(
+                model, example_input, str(path), dynamo=False, **export_kwargs
+            )
+        except TypeError:
+            torch.onnx.export(model, example_input, str(path), **export_kwargs)
+        print(f"ONNX-файл сохранён: {path}")
+        return path
+
+    @staticmethod
+    def check(path: Path) -> None:
+        """Проверка структуры файла через onnx.checker."""
+
+        onnx_model = onnx.load(str(path))
+        onnx.checker.check_model(onnx_model)
+        print("onnx.checker: структура модели корректна")
+
+
+class FedCoreOnnxRunner(nn.Module):
+    """Запуск .onnx через ``ONNXInferenceModel`` FedCore.
+
+    ``ONNXInferenceModel`` открывает файл через ONNX Runtime.
+    В текущей версии ``forward`` оборачивает весь список выходов ORT в
+    ``torch.Tensor``, из-за чего появляется лишнее измерение. Здесь берётся
+    первый выход и возвращается тензор формы ``(batch, classes)``.
+    """
+
+    def __init__(self, onnx_path: Path):
+        super().__init__()
+        # FedCore: загрузка сессии ONNX Runtime с именем входа "input".
+        self.backend = ONNXInferenceModel(str(onnx_path))
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        """Инференс с нормализацией формы ответа."""
+
+        raw = self.backend(inputs)
+        if isinstance(raw, (list, tuple)):
+            raw = raw[0]
+        if not isinstance(raw, torch.Tensor):
+            raw = torch.as_tensor(raw)
+        if raw.ndim == 3 and raw.shape[0] == 1:
+            raw = raw.squeeze(0)
+        return raw.float()
+
+
+class MetricEvaluator:
+    """Расчёт accuracy, размера артефакта и latency на CPU."""
+
+    @staticmethod
+    @torch.inference_mode()
+    def evaluate(
+        name: str,
+        model: nn.Module,
+        loader: DataLoader,
+        artifact_path: Path,
+    ) -> Metrics:
+        model.eval()
+        correct = total = 0
+        for images, labels in loader:
+            correct += (model(images).argmax(1) == labels).sum().item()
+            total += len(labels)
+
+        size = artifact_path.stat().st_size / 1024**2
+        sample = next(iter(loader))[0][:1]
+        for _ in range(3):
+            model(sample)
+        times = []
+        for _ in range(20):
+            started = time.perf_counter()
+            model(sample)
+            times.append((time.perf_counter() - started) * 1000)
+
+        return Metrics(name, correct / total, size, statistics.fmean(times))
+
+    @staticmethod
+    @torch.inference_mode()
+    def max_abs_difference(
+        pytorch_model: nn.Module, onnx_model: nn.Module, batch: torch.Tensor
+    ) -> float:
+        """Расчёт max |PyTorch − ONNX| на одном batch."""
+
+        left = pytorch_model(batch)
+        right = onnx_model(batch)
+        if left.shape != right.shape:
+            raise RuntimeError(
+                f"Формы не совпадают: PyTorch {tuple(left.shape)} "
+                f"vs ONNX {tuple(right.shape)}"
+            )
+        return float(torch.max(torch.abs(left - right)).item())
+
+    @staticmethod
+    @torch.inference_mode()
+    def check_dynamic_batch(onnx_model: nn.Module, sample: torch.Tensor) -> None:
+        """Проверка поддержки dynamic axes для batch=1 и batch=4."""
+
+        for batch_size in (1, 4):
+            batch = sample[:1].repeat(batch_size, 1, 1, 1)
+            output = onnx_model(batch)
+            if tuple(output.shape) != (batch_size, 10):
+                raise RuntimeError(
+                    f"Ожидалась shape={(batch_size, 10)}, получена {tuple(output.shape)}"
+                )
+            print(f"dynamic batch={batch_size}: OK, shape={tuple(output.shape)}")
+
+
+class Infographic:
+    """Сохранение PNG-сравнения PyTorch и ONNX."""
+
+    @staticmethod
+    def save(
+        pytorch: Metrics, onnx_metrics: Metrics, max_diff: float, path: Path
+    ) -> None:
+        colors = ["#3977d6", "#ef7d32"]
+        fig, axes = plt.subplots(1, 3, figsize=(13, 4.5))
+        fig.suptitle("FedCore: ResNet18 PyTorch vs ONNX", fontsize=16)
+        for axis, values, title, unit in (
+            (
+                axes[0],
+                [pytorch.accuracy, onnx_metrics.accuracy],
+                "Accuracy",
+                "доля",
+            ),
+            (
+                axes[1],
+                [pytorch.size_mib, onnx_metrics.size_mib],
+                "Размер файла",
+                "MiB",
+            ),
+            (
+                axes[2],
+                [pytorch.latency_ms, onnx_metrics.latency_ms],
+                "Latency batch=1",
+                "ms",
+            ),
+        ):
+            bars = axis.bar(["PyTorch", "ONNX"], values, color=colors)
+            axis.set_title(title)
+            axis.set_ylabel(unit)
+            axis.grid(axis="y", alpha=0.25)
+            axis.bar_label(bars, fmt="%.3f", padding=3)
+        fig.text(
+            0.5,
+            0.01,
+            f"max |PyTorch − ONNX| = {max_diff:.6f}",
+            ha="center",
+        )
+        fig.tight_layout(rect=(0, 0.06, 1, 0.92))
+        fig.savefig(path, dpi=160)
+        plt.close(fig)
+
+
+def section(number: int, title: str, text: str) -> None:
+    """Печать этапа эксперимента в консоль."""
+
+    print(f"\n{'=' * 72}\nЭТАП {number}. {title}\n{'=' * 72}\n{text}")
+
+
+def save_report(metrics: list[Metrics], max_diff: float, path: Path) -> None:
+    """Сохранение CSV-отчёта сравнения."""
+
+    rows = []
+    for item in metrics:
+        row = asdict(item)
+        row["max_abs_difference"] = max_diff
+        rows.append(row)
+    with path.open("w", newline="", encoding="utf-8") as file:
+        writer = csv.DictWriter(file, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def parse_args() -> Config:
+    """Разбор параметров эксперимента из командной строки."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--train-samples", type=int, default=2_000)
+    parser.add_argument("--test-samples", type=int, default=500)
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--opset-version", type=int, default=17)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=REPO_ROOT / "results" / "export_onnx",
+    )
+    args = parser.parse_args()
+    return Config(
+        epochs=args.epochs,
+        train_samples=args.train_samples,
+        test_samples=args.test_samples,
+        batch_size=args.batch_size,
+        opset_version=args.opset_version,
+        output_dir=args.output_dir.resolve(),
+    )
+
+
+def main() -> None:
+    """Последовательность: частичное обучение → экспорт → сравнение."""
+
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
+
+    config = parse_args()
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    random.seed(config.seed)
+    np.random.seed(config.seed)
+    torch.manual_seed(config.seed)
+
+    section(
+        1,
+        "Данные",
+        "Загрузка CIFAR-10 и подготовка train/test DataLoader.",
+    )
+    data = Cifar10Data(config)
+    print(f"train={len(data.train.dataset)}, test={len(data.test.dataset)}")
+
+    section(
+        2,
+        "Исходная FP32-модель",
+        "Создание ResNet18 из CLF_MODELS FedCore и частичное обучение.",
+    )
+    pytorch_model = ResNet18ExperimentModel.create()
+    ResNet18ExperimentModel.train(pytorch_model, data.train, config.epochs)
+    state_dict_path = config.output_dir / "resnet18_fp32_state_dict.pt"
+    torch.save(pytorch_model.state_dict(), state_dict_path)
+    pytorch_metrics = MetricEvaluator.evaluate(
+        "pytorch", pytorch_model, data.test, state_dict_path
+    )
+    print(pytorch_metrics)
+
+    section(
+        3,
+        "Экспорт в ONNX",
+        "Сохранение графа и весов через torch.onnx.export; "
+        "проверка структуры через onnx.checker.",
+    )
+    example_input = next(iter(data.test))[0][:1]
+    onnx_path = config.output_dir / "resnet18.onnx"
+    OnnxExporter.export(
+        pytorch_model, example_input, onnx_path, config.opset_version
+    )
+    OnnxExporter.check(onnx_path)
+
+    section(
+        4,
+        "FedCore-инференс и сравнение",
+        "Запуск .onnx через ONNXInferenceModel; сравнение ответов с PyTorch.",
+    )
+    onnx_model = FedCoreOnnxRunner(onnx_path)
+    MetricEvaluator.check_dynamic_batch(onnx_model, example_input)
+    max_diff = MetricEvaluator.max_abs_difference(
+        pytorch_model, onnx_model, example_input
+    )
+    print(f"max |PyTorch − ONNX| = {max_diff:.6f}")
+    if max_diff > 1e-4:
+        raise RuntimeError(
+            f"Слишком большое расхождение ответов: {max_diff:.6f} > 1e-4"
+        )
+
+    onnx_metrics = MetricEvaluator.evaluate(
+        "onnx", onnx_model, data.test, onnx_path
+    )
+    print(onnx_metrics)
+
+    section(5, "CSV + инфографика", "Сохранение отчёта и PNG-сравнения.")
+    save_report(
+        [pytorch_metrics, onnx_metrics],
+        max_diff,
+        config.output_dir / "export_report.csv",
+    )
+    Infographic.save(
+        pytorch_metrics,
+        onnx_metrics,
+        max_diff,
+        config.output_dir / "onnx_comparison.png",
+    )
+    print(f"Результаты: {config.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/quantization_resnet18/run_quantization_resnet18.py
+++ b/examples/quantization_resnet18/run_quantization_resnet18.py
@@ -1,0 +1,492 @@
+"""Обучение исходной ResNet18 и статическая INT8-квантизация через FedCore.
+
+Структура эксперимента:
+1. Загрузка CIFAR-10.
+2. Создание ResNet18 из реестра CLF_MODELS FedCore.
+3. Полноценное обучение FP32-модели на train-выборке.
+4. Передача обученной модели в BaseQuantizer и получение INT8-модели.
+5. Сравнение accuracy, размера файла и latency; сохранение CSV и PNG.
+
+Выбрана static post-training quantization (статическая квантизация после
+обучения), потому что ResNet18 почти целиком состоит из свёрточных слоёв:
+
+* dynamic quantization хорошо ускоряет Linear-слои, но в ResNet18 они занимают
+  малую часть вычислений;
+* QAT имитирует INT8 прямо во время обучения и может лучше сохранить accuracy,
+  но заметно усложняет учебный пример;
+* static PTQ даёт понятный цикл: сначала обучение FP32, затем калибровка без
+  обучения и однократное преобразование в INT8.
+
+Модули FedCore в примере:
+* CLF_MODELS — реестр архитектур; отсюда берётся ResNet18;
+* CompressionInputData — контейнер модели и DataLoader для BaseQuantizer;
+* BaseQuantizer — prepare → calibration → convert;
+* QDQWrapper / QDQWrapping — границы Quantize/DeQuantize вокруг leaf-слоёв.
+
+Запуск::
+
+    cd examples/quantization_resnet18
+    python run_quantization_resnet18.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import csv
+import logging
+import random
+import statistics
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from fedot.core.repository.tasks import Task, TaskTypesEnum
+from torch import nn
+from torch.utils.data import DataLoader, Subset
+from torchvision import datasets, transforms
+
+from fedcore.algorithm.quantization.quantizers import BaseQuantizer
+from fedcore.algorithm.quantization.utils import QDQWrapper, QDQWrapping
+from fedcore.data.data import CompressionInputData
+from fedcore.models.backbone.convolutional.resnet import CLF_MODELS
+
+
+@dataclass
+class Config:
+    """Параметры воспроизводимого эксперимента квантизации."""
+
+    seed: int = 42
+    epochs: int = 10
+    train_samples: int = 50_000
+    test_samples: int = 10_000
+    calibration_samples: int = 1_024
+    batch_size: int = 64
+    learning_rate: float = 1e-3
+    output_dir: Path = REPO_ROOT / "results" / "quantization_resnet18"
+    data_dir: Path = REPO_ROOT / "datasets"
+
+
+@dataclass
+class Metrics:
+    """Метрики одной версии модели для CSV и инфографики."""
+
+    model: str
+    accuracy: float
+    size_mib: float
+    latency_ms: float
+    quantized_modules: int
+
+
+class RunnableBaseQuantizer(BaseQuantizer):
+    """Адаптер к текущей версии FedCore для исполняемого static PTQ.
+
+    ``BaseQuantizer.fit`` уже содержит рабочий static PTQ, но класс формально
+    не реализует один abstract-метод родителя. Training hooks имеют устаревшую
+    сигнатуру и для PTQ не нужны: обучение уже завершено. Адаптер не заменяет
+    алгоритм — prepare/calibration/convert выполняются исходным ``fit``.
+
+    Свойства model_before/model_after хранят модели в памяти и не запускают
+    ModelRegistry: для одного примера промежуточный registry избыточен.
+    """
+
+    @property
+    def model_before(self):
+        return self._model_before_cached
+
+    @model_before.setter
+    def model_before(self, model):
+        self._model_before_cached = model
+
+    @property
+    def model_after(self):
+        return self._model_after_cached
+
+    @model_after.setter
+    def model_after(self, model):
+        self._model_after_cached = model
+
+    def _init_hooks(self, input_data):
+        """Отключение training hooks: static PTQ выполняется после обучения."""
+
+        self._on_epoch_start, self._on_epoch_end = [], []
+
+    def _init_trainer_model_before_model_after_and_incapsulate_hooks(
+        self, input_data
+    ):
+        """Реализация abstract-контракта родительского класса."""
+
+        self._init_model(input_data)
+
+
+class Cifar10Data:
+    """Загрузка CIFAR-10 и подготовка train/test/calibration DataLoader.
+
+    CIFAR-10 содержит 60 000 цветных изображений 32×32 десяти классов:
+    самолёт, автомобиль, птица, кошка, олень, собака, лягушка, лошадь,
+    корабль и грузовик. По умолчанию используется полный train/test набор;
+    размер можно уменьшить аргументами CLI для ускорения прогона.
+    """
+
+    def __init__(self, config: Config):
+        transform = transforms.Compose(
+            [
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    (0.4914, 0.4822, 0.4465),
+                    (0.2470, 0.2435, 0.2616),
+                ),
+            ]
+        )
+        train = datasets.CIFAR10(
+            config.data_dir, train=True, download=True, transform=transform
+        )
+        test = datasets.CIFAR10(
+            config.data_dir, train=False, download=True, transform=transform
+        )
+        generator = torch.Generator().manual_seed(config.seed)
+        train_ids = torch.randperm(len(train), generator=generator)
+        test_ids = torch.randperm(len(test), generator=generator)
+
+        n_train = min(config.train_samples, len(train))
+        n_test = min(config.test_samples, len(test))
+        n_calib = min(config.calibration_samples, n_train)
+
+        self.train = DataLoader(
+            Subset(train, train_ids[:n_train]),
+            batch_size=config.batch_size,
+            shuffle=True,
+            num_workers=0,
+            generator=generator,
+        )
+        self.calibration = DataLoader(
+            Subset(train, train_ids[:n_calib]),
+            batch_size=config.batch_size,
+            shuffle=False,
+            num_workers=0,
+        )
+        self.test = DataLoader(
+            Subset(test, test_ids[:n_test]),
+            batch_size=config.batch_size,
+            shuffle=False,
+            num_workers=0,
+        )
+
+
+class ResNet18ExperimentModel:
+    """Создание и обучение исходной FP32 ResNet18 для CIFAR-10."""
+
+    @staticmethod
+    def create() -> nn.Module:
+        """Создание ResNet18 из FedCore с входом под изображения 32×32."""
+
+        # FedCore: CLF_MODELS — реестр classification-backbone.
+        model = CLF_MODELS["ResNet18"](weights=None, num_classes=10)
+        model.conv1 = nn.Conv2d(3, 64, 3, stride=1, padding=1, bias=False)
+        model.maxpool = nn.Identity()
+        return model.cpu()
+
+    @staticmethod
+    @torch.inference_mode()
+    def evaluate(model: nn.Module, loader: DataLoader) -> tuple[float, float]:
+        """Расчёт loss и accuracy на переданном DataLoader."""
+
+        model.eval()
+        loss_function = nn.CrossEntropyLoss()
+        loss_sum, correct, total = 0.0, 0, 0
+        for images, labels in loader:
+            logits = model(images)
+            loss_sum += loss_function(logits, labels).item() * len(labels)
+            correct += (logits.argmax(1) == labels).sum().item()
+            total += len(labels)
+        return loss_sum / total, correct / total
+
+    @staticmethod
+    def train(
+        model: nn.Module,
+        train_loader: DataLoader,
+        test_loader: DataLoader,
+        epochs: int,
+        learning_rate: float,
+    ) -> None:
+        """Полный FP32-цикл обучения с валидацией после каждой эпохи.
+
+        На каждой эпохе:
+        1. model.train() — включение Dropout/BatchNorm в режиме обучения;
+        2. forward → CrossEntropyLoss → backward → Adam.step;
+        3. model.eval() и оценка на test-выборке без градиентов;
+        4. StepLR уменьшает learning rate каждые 4 эпохи.
+        """
+
+        optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
+        scheduler = torch.optim.lr_scheduler.StepLR(
+            optimizer, step_size=4, gamma=0.5
+        )
+        loss_function = nn.CrossEntropyLoss()
+
+        for epoch in range(epochs):
+            model.train()
+            loss_sum, correct, total = 0.0, 0, 0
+            for images, labels in train_loader:
+                optimizer.zero_grad()
+                logits = model(images)
+                loss = loss_function(logits, labels)
+                loss.backward()
+                optimizer.step()
+                loss_sum += loss.item() * len(labels)
+                correct += (logits.argmax(1) == labels).sum().item()
+                total += len(labels)
+
+            train_loss = loss_sum / total
+            train_acc = correct / total
+            val_loss, val_acc = ResNet18ExperimentModel.evaluate(
+                model, test_loader
+            )
+            scheduler.step()
+            print(
+                f"Epoch {epoch + 1}/{epochs}: "
+                f"train_loss={train_loss:.4f}, train_acc={train_acc:.2%}, "
+                f"val_loss={val_loss:.4f}, val_acc={val_acc:.2%}, "
+                f"lr={scheduler.get_last_lr()[0]:.5f}"
+            )
+        model.eval()
+
+
+class FedCoreStaticQuantizer:
+    """Преобразование обученной FP32 ResNet18 в INT8 через BaseQuantizer.
+
+    Q/DQ означает Quantize/DeQuantize — границы между FP32-тензорами и
+    INT8-слоями. В текущем FedCore автоматические границы не покрывают
+    torchvision ResNet18, поэтому QDQWrapping явно ставится вокруг Conv2d,
+    BatchNorm2d и Linear. Residual-сложения остаются в FP32.
+    """
+
+    @staticmethod
+    def quantize(model: nn.Module, calibration: DataLoader) -> nn.Module:
+        engine = (
+            "fbgemm"
+            if "fbgemm" in torch.backends.quantized.supported_engines
+            else "x86"
+        )
+        # FedCore: BaseQuantizer выполняет static PTQ.
+        quantizer = RunnableBaseQuantizer(
+            {
+                "quant_type": "static",
+                "backend": engine,
+                "device": torch.device("cpu"),
+                "dtype": torch.qint8,
+                "allow_conv": True,
+            }
+        )
+        quantizer.logger.setLevel(logging.WARNING)
+
+        qconfig = quantizer.qconfig[""]
+        model = copy.deepcopy(model).eval()
+        layers = [
+            (name, layer)
+            for name, layer in model.named_modules()
+            if name and isinstance(layer, (nn.Conv2d, nn.BatchNorm2d, nn.Linear))
+        ]
+        for name, layer in layers:
+            layer.qconfig = qconfig
+            # FedCore: QDQWrapper / QDQWrapping — явные Q/DQ-границы.
+            QDQWrapper.set_module(
+                model, name, QDQWrapping(layer, mode="both", qconfig=qconfig)
+            )
+
+        # FedCore: CompressionInputData — контракт данных для quantizer.fit.
+        data = CompressionInputData(
+            features=np.zeros((1, 1), dtype=np.float32),
+            target=model,
+            train_dataloader=calibration,
+            val_dataloader=calibration,
+            task=Task(TaskTypesEnum.classification),
+            input_dim=3,
+            num_classes=10,
+        )
+        print(
+            f"FedCore: prepare → calibration ({len(calibration.dataset)} images) "
+            "→ convert to INT8"
+        )
+        return quantizer.fit(data).cpu().eval()
+
+
+class MetricEvaluator:
+    """Расчёт accuracy, размера state_dict и latency на CPU."""
+
+    @staticmethod
+    @torch.inference_mode()
+    def evaluate(
+        name: str, model: nn.Module, loader: DataLoader, output_dir: Path
+    ) -> Metrics:
+        model.eval()
+        correct = total = 0
+        for images, labels in loader:
+            correct += (model(images).argmax(1) == labels).sum().item()
+            total += len(labels)
+
+        path = output_dir / f"resnet18_{name}_state_dict.pt"
+        torch.save(model.state_dict(), path)
+        size = path.stat().st_size / 1024**2
+
+        sample = next(iter(loader))[0][:1]
+        for _ in range(3):
+            model(sample)
+        times = []
+        for _ in range(20):
+            started = time.perf_counter()
+            model(sample)
+            times.append((time.perf_counter() - started) * 1000)
+
+        quantized = sum(
+            ".quantized" in layer.__class__.__module__.lower()
+            for layer in model.modules()
+        )
+        return Metrics(
+            name, correct / total, size, statistics.fmean(times), quantized
+        )
+
+
+class Infographic:
+    """Сохранение PNG-сравнения исходной FP32 и INT8-модели."""
+
+    @staticmethod
+    def save(fp32: Metrics, int8: Metrics, path: Path) -> None:
+        colors = ["#3977d6", "#ef7d32"]
+        fig, axes = plt.subplots(1, 3, figsize=(13, 4.5))
+        fig.suptitle("FedCore: ResNet18 до и после static INT8 PTQ", fontsize=16)
+        for axis, values, title, unit in (
+            (axes[0], [fp32.accuracy, int8.accuracy], "Accuracy", "доля"),
+            (axes[1], [fp32.size_mib, int8.size_mib], "Размер state_dict", "MiB"),
+            (axes[2], [fp32.latency_ms, int8.latency_ms], "Latency batch=1", "ms"),
+        ):
+            bars = axis.bar(["FP32", "INT8"], values, color=colors)
+            axis.set_title(title)
+            axis.set_ylabel(unit)
+            axis.grid(axis="y", alpha=0.25)
+            axis.bar_label(bars, fmt="%.3f", padding=3)
+        fig.text(
+            0.5,
+            0.01,
+            f"Уменьшение размера: {fp32.size_mib / int8.size_mib:.2f}×; "
+            f"ускорение: {fp32.latency_ms / int8.latency_ms:.2f}×; "
+            f"INT8-модулей: {int8.quantized_modules}",
+            ha="center",
+        )
+        fig.tight_layout(rect=(0, 0.06, 1, 0.92))
+        fig.savefig(path, dpi=160)
+        plt.close(fig)
+
+
+def section(number: int, title: str, text: str) -> None:
+    """Печать этапа эксперимента в консоль."""
+
+    print(f"\n{'=' * 72}\nЭТАП {number}. {title}\n{'=' * 72}\n{text}")
+
+
+def save_report(metrics: list[Metrics], path: Path) -> None:
+    """Сохранение таблицы сравнения в CSV."""
+
+    with path.open("w", newline="", encoding="utf-8") as file:
+        writer = csv.DictWriter(file, fieldnames=list(asdict(metrics[0])))
+        writer.writeheader()
+        writer.writerows(asdict(metric) for metric in metrics)
+
+
+def parse_args() -> Config:
+    """Разбор параметров эксперимента из командной строки."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--train-samples", type=int, default=50_000)
+    parser.add_argument("--test-samples", type=int, default=10_000)
+    parser.add_argument("--calibration-samples", type=int, default=1_024)
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--learning-rate", type=float, default=1e-3)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=REPO_ROOT / "results" / "quantization_resnet18",
+    )
+    args = parser.parse_args()
+    return Config(
+        epochs=args.epochs,
+        train_samples=args.train_samples,
+        test_samples=args.test_samples,
+        calibration_samples=args.calibration_samples,
+        batch_size=args.batch_size,
+        learning_rate=args.learning_rate,
+        output_dir=args.output_dir.resolve(),
+    )
+
+
+def main() -> None:
+    """Последовательность: обучение → static PTQ → сравнение метрик."""
+
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
+    config = parse_args()
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    random.seed(config.seed)
+    np.random.seed(config.seed)
+    torch.manual_seed(config.seed)
+
+    section(
+        1,
+        "Данные",
+        "Загрузка CIFAR-10 и подготовка train/test/calibration DataLoader.",
+    )
+    data = Cifar10Data(config)
+    print(
+        f"train={len(data.train.dataset)}, test={len(data.test.dataset)}, "
+        f"calibration={len(data.calibration.dataset)}"
+    )
+
+    section(
+        2,
+        "Исходная модель",
+        "Создание ResNet18 из CLF_MODELS FedCore и полноценное FP32-обучение.",
+    )
+    fp32_model = ResNet18ExperimentModel.create()
+    ResNet18ExperimentModel.train(
+        fp32_model,
+        data.train,
+        data.test,
+        config.epochs,
+        config.learning_rate,
+    )
+    fp32 = MetricEvaluator.evaluate("fp32", fp32_model, data.test, config.output_dir)
+    print(fp32)
+
+    section(
+        3,
+        "Static INT8 PTQ",
+        "Обучение завершено. Калибровка только наблюдает диапазоны значений; "
+        "BaseQuantizer выполняет prepare → convert.",
+    )
+    int8_model = FedCoreStaticQuantizer.quantize(fp32_model, data.calibration)
+    int8 = MetricEvaluator.evaluate("int8", int8_model, data.test, config.output_dir)
+    if int8.quantized_modules == 0 or int8.size_mib >= fp32.size_mib:
+        raise RuntimeError("Проверка не подтвердила настоящую INT8-квантизацию.")
+    print(int8)
+
+    section(4, "Результаты", "Сохранение CSV-таблицы и PNG-инфографики.")
+    save_report([fp32, int8], config.output_dir / "metrics.csv")
+    Infographic.save(
+        fp32, int8, config.output_dir / "quantization_comparison.png"
+    )
+    print(f"Уменьшение размера: {fp32.size_mib / int8.size_mib:.2f}×")
+    print(f"Ускорение: {fp32.latency_ms / int8.latency_ms:.2f}×")
+    print(f"Результаты: {config.output_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

| Пример | Путь | Команда из README |
|---|---|---|
| Static INT8-квантизация | `examples/quantization_resnet18/` | `cd examples/quantization_resnet18` → `python run_quantization_resnet18.py` |
| Экспорт в ONNX | `examples/export_onnx/` | `cd examples/export_onnx` → `python export_to_onnx.py` |

Оба примера используют архитектуру ResNet18 из реестра FedCore, датасет CIFAR-10 и сохраняют отчёты в `results/`.

---

## Зависимости примеров

Часть пакетов уже входит в `requirements.txt` проекта, часть нужна только для runnable-примеров и **не ставится автоматически** при установке FedCore.

### Уже ожидаются при установке проекта

| Пакет | Назначение в примерах |
|---|---|
| `torch` / `torchvision` | Модель, обучение, экспорт ONNX |
| `onnxruntime` | Инференс через `ONNXInferenceModel` |
| `fedot`, `PyMonad` и др. | Транзитивные зависимости импорта FedCore |

`torch` в `requirements.txt` указан комментарием и обычно ставится отдельно (CPU или CUDA).

### Дополнительно для примеров

| Пакет | Нужен для | Установка |
|---|---|---|
| `matplotlib` | PNG-инфографика обоих примеров | `pip install matplotlib` |
| `onnx` | `onnx.checker` в примере экспорта | `pip install onnx` |

Рекомендуемая установка перед запуском:

```bash
pip install -e .
pip install matplotlib onnx
# при отсутствии PyTorch:
# pip install torch==2.3.1 torchvision==0.18.1 --index-url https://download.pytorch.org/whl/cpu
```

---

## Общая постановка

### Что обучается

Обучается **одна** исходная FP32 ResNet18 для многоклассовой классификации на CIFAR-10 (10 классов, изображения 32×32).

Модель берётся из реестра FedCore `CLF_MODELS["ResNet18"]` (`fedcore/models/backbone/convolutional/resnet.py`). Для CIFAR-10 входной слой адаптируется:

- `conv1`: свёртка 3×3 вместо ImageNet-варианта 7×7;
- `maxpool`: заменяется на `Identity`, чтобы не сжимать маленькое изображение слишком рано.

### Почему CIFAR-10

- многоклассовая задача, подходящая для ResNet18;
- автоматически загружается torchvision;
- достаточно компактен для воспроизводимого демо на CPU.

### Почему разные режимы обучения в двух примерах

| Пример | Режим обучения | Почему |
|---|---|---|
| Квантизация | Полноценный цикл (по умолчанию 10 эпох, полный train/test) | Нужен содержательный baseline accuracy до/после INT8 |
| ONNX | Частичный цикл (по умолчанию 1 эпоха, урезанная выборка) | Цель — корректный экспорт и совпадение ответов, не максимальная accuracy |

---

## Пример 1. Квантизация ResNet18

### Назначение

Показать static post-training quantization (PTQ) после обучения:

1. обучение FP32-модели;
2. калибровка без градиентов;
3. преобразование в INT8 через `BaseQuantizer`;
4. сравнение accuracy / размера / latency.

### Почему выбран static PTQ

- ResNet18 состоит в основном из свёрток; dynamic quantization сильнее помогает Linear-слоям;
- QAT длиннее и сложнее для демонстрационного примера;
- static PTQ даёт понятный цикл: обучение → калибровка → convert.

Static PTQ **не обучает** модель заново: после `eval()` калибровочные изображения только помогают оценить диапазоны активаций.

### Как запускать

```bash
cd examples/quantization_resnet18
python run_quantization_resnet18.py
```

Параметры CLI:

| Аргумент | По умолчанию | Смысл |
|---|---|---|
| `--epochs` | `10` | Число эпох FP32-обучения |
| `--train-samples` | `50000` | Размер train-подвыборки |
| `--test-samples` | `10000` | Размер test-подвыборки |
| `--calibration-samples` | `1024` | Число изображений для калибровки INT8 |
| `--batch-size` | `64` | Размер batch |
| `--learning-rate` | `0.001` | Learning rate Adam |
| `--output-dir` | `results/quantization_resnet18` | Каталог артефактов |

Ускоренный прогон (как в рабочем запуске ниже):

```bash
python run_quantization_resnet18.py --epochs 3 --train-samples 5000 --test-samples 1000
```

### Как организовано обучение

На каждой эпохе:

1. `model.train()`;
2. `forward → CrossEntropyLoss → backward → Adam.step`;
3. оценка на test без градиентов (`val_loss`, `val_acc`);
4. `StepLR`: learning rate уменьшается в 2 раза каждые 4 эпохи.

### Модули FedCore

| Модуль | Файл | Что внутри / зачем в примере |
|---|---|---|
| `CLF_MODELS` | `fedcore/models/backbone/convolutional/resnet.py` | Словарь backbone; ключ `"ResNet18"` → `torchvision.models.resnet18` |
| `CompressionInputData` | `fedcore/data/data.py` | Контейнер: `target` (модель), `train_dataloader` / `val_dataloader` |
| `BaseQuantizer` | `fedcore/algorithm/quantization/quantizers.py` | Static/dynamic/QAT; в примере — `quant_type="static"`: prepare → calibration → convert |
| `QDQWrapper`, `QDQWrapping` | `fedcore/algorithm/quantization/utils.py` | Явные Quantize/DeQuantize-границы вокруг Conv/BN/Linear |

В скрипте используется адаптер `RunnableBaseQuantizer`: он обходит два дефекта текущей ветки (abstract-метод родителя и несовместимые training hooks), но алгоритм PTQ выполняет исходный `BaseQuantizer.fit`.

### Что ожидается в консоли

Этапы:

1. **Данные** — размеры train/test/calibration;
2. **Исходная модель** — строки `Epoch ... train_loss/acc, val_loss/acc`;
3. **Static INT8 PTQ** — сообщение `prepare → calibration → convert`;
4. **Результаты** — коэффициенты уменьшения размера и ускорения.

Служебные сообщения FedCore (`@@@ before bt`, многократные `Device <cpu> is selected`, логи `ModelRegistry`) являются шумом инфраструктуры и не являются ошибкой, если этапы завершаются и печатаются итоговые `Metrics`.

### Фактический прогон

Команда:

```bash
python run_quantization_resnet18.py --epochs 3 --train-samples 5000 --test-samples 1000
```

Наблюдаемый ход обучения:

| Эпоха | train_acc | val_acc |
|---|---|---|
| 1 | 33.96% | 30.40% |
| 2 | 46.30% | 41.80% |
| 3 | 54.90% | 50.60% |

Итог:

| Модель | Accuracy | Размер | Latency | INT8-модули |
|---|---|---|---|---|
| FP32 | 0.506 | 42.701 MiB | 19.826 ms | 0 |
| INT8 | 0.508 | 10.815 MiB | 8.228 ms | 124 |

- уменьшение размера: **3.95×**;
- ускорение: **2.41×**;
- accuracy после квантизации не упала (на данном прогоне даже +0.002 — в пределах шума малой выборки).

### Интерпретация метрик квантизации

| Метрика | Как читать |
|---|---|
| **Accuracy** | Доля верных классов на test. Главный критерий качества PTQ: INT8 не должна сильно отставать от FP32. Здесь 0.506 → 0.508 — успешный перенос. |
| **size_mib** | Размер `state_dict` на диске. Для INT8 ожидается сжатие около 4× относительно FP32. |
| **latency_ms** | Среднее время инференса batch=1 на CPU. Зависит от загрузки машины; важнее относительное ускорение, чем абсолютные миллисекунды. |
| **quantized_modules** | Число реально преобразованных INT8-модулей. `0` означало бы сбой (возврат исходной FP32). `124` подтверждает успешный convert. |

Важно: при `--epochs 3 --train-samples 5000` accuracy ~50% — ожидаемый учебный уровень, не SOTA. Для более сильного baseline:

```bash
python run_quantization_resnet18.py --epochs 10 --train-samples 50000 --test-samples 10000
```

### Выходные файлы квантизации

Каталог: `results/quantization_resnet18/`

| Файл | Что это | Что видно |
|---|---|---|
| `resnet18_fp32_state_dict.pt` | Веса обученной FP32-модели | Исходный baseline (~42.7 MiB) |
| `resnet18_int8_state_dict.pt` | Веса после static PTQ | Сжатый INT8-артефакт (~10.8 MiB) |
| `metrics.csv` | Таблица сравнения FP32/INT8 | Accuracy, размер, latency, число INT8-модулей |
| `quantization_comparison.png` | Инфографика | Три столбчатых графика: accuracy, размер, latency |

Чтение `metrics.csv` из прогона:

```text
model,accuracy,size_mib,latency_ms,quantized_modules
fp32,0.506,42.70...,19.82...,0
int8,0.508,10.81...,8.22...,124
```

---

## Пример 2. Экспорт ResNet18 в ONNX

### Назначение

Показать перенос обученной (или частично обученной) FP32-модели в переносимый формат ONNX и запуск через FedCore:

1. частичное обучение FP32;
2. `torch.onnx.export`;
3. проверка `onnx.checker`;
4. инференс через `ONNXInferenceModel`;
5. сравнение ответов PyTorch и ONNX.

### Почему частичное обучение здесь допустимо

Экспорт не меняет веса. Критерий успеха — структурная валидность `.onnx` и численное совпадение выходов (`max |PyTorch − ONNX|`), а не высокая accuracy. Поэтому по умолчанию используется короткий цикл (1 эпоха, 2000 train / 500 test).

### Как запускать

```bash
cd examples/export_onnx
python export_to_onnx.py
```

Параметры CLI:

| Аргумент | По умолчанию | Смысл |
|---|---|---|
| `--epochs` | `1` | Число эпох частичного обучения |
| `--train-samples` | `2000` | Размер train-подвыборки |
| `--test-samples` | `500` | Размер test-подвыборки |
| `--batch-size` | `64` | Размер batch |
| `--opset-version` | `17` | Версия ONNX opset |
| `--output-dir` | `results/export_onnx` | Каталог артефактов |

### Модули FedCore

| Модуль | Файл | Что внутри / зачем в примере |
|---|---|---|
| `CLF_MODELS` | `fedcore/models/backbone/convolutional/resnet.py` | Создание ResNet18 |
| `ONNXInferenceModel` | `fedcore/inference/onnx.py` | Обёртка ONNX Runtime; вход жёстко называется `"input"` |

`FedCore.export()` (`fedcore/api/main.py`) **не используется**: метод сейчас пустой (`pass`). Экспорт выполняется через `torch.onnx.export`.

В примере класс `FedCoreOnnxRunner` нормализует выход `ONNXInferenceModel`: текущая реализация иногда возвращает лишнее измерение вокруг списка ORT-выходов.

### Что ожидается в консоли

1. **Данные** — размеры train/test;
2. **Исходная FP32-модель** — строка эпохи частичного обучения;
3. **Экспорт в ONNX** — путь к `.onnx` и сообщение `onnx.checker: структура модели корректна`;
4. **FedCore-инференс** — `dynamic batch=1/4: OK`, `max |PyTorch − ONNX|`;
5. **CSV + инфографика** — путь к `results/export_onnx`.

### Фактический прогон

Команда по умолчанию:

```bash
python export_to_onnx.py
```

Итог:

| Модель | Accuracy | Размер | Latency |
|---|---|---|---|
| PyTorch | 0.292 | 42.701 MiB | 17.901 ms |
| ONNX | 0.292 | 42.616 MiB | 5.625 ms |

Дополнительно:

- `dynamic batch=1` и `batch=4`: OK;
- `max |PyTorch − ONNX| = 0.000001` (порядка 1e-6) — численный паритет;
- accuracy одинаковая: экспорт не изменил поведение классификатора.

### Интерпретация метрик экспорта

| Метрика | Как читать |
|---|---|
| **Accuracy** | Должна совпасть у PyTorch и ONNX на одном test-наборе. Здесь 0.292 = 0.292. Низкое абсолютное значение ожидаемо из-за частичного обучения. |
| **size_mib** | Размер `.pt` vs `.onnx`. Для FP32-экспорта размеры обычно близки; ONNX не обязан сильно сжимать модель. |
| **latency_ms** | Время batch=1. ONNX Runtime часто быстрее eager-PyTorch на CPU; здесь ускорение примерно 3.2×. Абсолютные значения зависят от машины. |
| **max_abs_difference** | Максимум \|logit_pytorch − logit_onnx\| на одном batch. Порог успеха в скрипте: ≤ 1e-4. Получено ~1e-6 — отличный паритет. |
| **dynamic batch** | Проверка, что один `.onnx` принимает разный размер batch без переэкспорта. |

### Выходные файлы экспорта

Каталог: `results/export_onnx/`

| Файл | Что это | Что видно |
|---|---|---|
| `resnet18_fp32_state_dict.pt` | Веса PyTorch-модели | Исходный checkpoint (~42.7 MiB) |
| `resnet18.onnx` | Экспортированный граф + веса | Переносимый артефакт для ONNX Runtime (~42.6 MiB) |
| `export_report.csv` | Таблица сравнения | Accuracy, размеры, latency, max_abs_difference |
| `onnx_comparison.png` | Инфографика | Accuracy / размер / latency PyTorch vs ONNX |

Чтение `export_report.csv` из прогона:

```text
model,accuracy,size_mib,latency_ms,max_abs_difference
pytorch,0.292,42.70...,17.90...,5.96e-07
onnx,0.292,42.61...,5.62...,5.96e-07
```

---

## Краткая оценка выполненных запусков

### Квантизация

Запуск :

- обучение растёт по эпохам (val_acc 30% → 51%);
- INT8 реально создан (`quantized_modules=124`);
- размер уменьшен в 3.95×;
- latency улучшена в 2.41×;
- accuracy сохранена.

Это корректная демонстрация static PTQ на ResNet18 через FedCore.

### Экспорт ONNX

Запуск:

- файл прошёл `onnx.checker`;
- dynamic batch работает;
- численный паритет почти полный;
- accuracy PyTorch и ONNX совпали;
- ONNX Runtime дал заметное ускорение на CPU.


---

## Структура артефактов после запусков

```text
results/
  quantization_resnet18/
    metrics.csv
    quantization_comparison.png
    resnet18_fp32_state_dict.pt
    resnet18_int8_state_dict.pt
  export_onnx/
    export_report.csv
    onnx_comparison.png
    resnet18_fp32_state_dict.pt
    resnet18.onnx
```
